### PR TITLE
Chaos Workflow to validate data consistency and availability

### DIFF
--- a/ngc-monkey/.dockerignore
+++ b/ngc-monkey/.dockerignore
@@ -1,0 +1,2 @@
+**/__pycache__
+.DS_Store

--- a/ngc-monkey/.gitignore
+++ b/ngc-monkey/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+.DS_Store

--- a/ngc-monkey/Dockerfile.server
+++ b/ngc-monkey/Dockerfile.server
@@ -1,0 +1,9 @@
+FROM python:3.11.1-buster
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
+COPY ./ ./ngc-monkey
+WORKDIR /ngc-monkey
+
+EXPOSE 5000
+CMD ["python", "-m", "ngc-monkey"]

--- a/ngc-monkey/Makefile
+++ b/ngc-monkey/Makefile
@@ -1,0 +1,21 @@
+PORT=5000
+SERVER_APP=ngc-monkey-server
+
+build:
+	docker build -f Dockerfile.server -t $(SERVER_APP) .
+
+run: build
+	docker run -p $(PORT):$(PORT) -it $(SERVER_APP)
+
+push: build
+	docker tag $(SERVER_APP) gcr.io/redis-dev-next-gen-cluster/$(SERVER_APP)
+	docker push gcr.io/redis-dev-next-gen-cluster/$(SERVER_APP)
+
+deploy:
+	kubectl apply -f k8s/deployment.yaml
+
+undeploy:
+	kubectl delete -f k8s/deployment.yaml
+
+port-for:
+	kubectl port-forward service/ngc-monkey $(PORT):$(PORT)

--- a/ngc-monkey/README.md
+++ b/ngc-monkey/README.md
@@ -1,0 +1,33 @@
+# NGC-Monkey
+`NGC-Monkey` is a small web app that assists in chaos testing.
+It currently supports a small set of commands that allows the test
+[probes](https://docs.litmuschaos.io/docs/2.14.0/concepts/probes#comparator) 
+to check stateful scenarios.
+It uses port 5000 (same as flask tutorial)
+
+## Development
+`NGC-Monkey` is a web application written in python based on Flask. 
+There is a simple makefile to automate the usual workflow:
+
+* `make build` - build a docker image
+* `make run` - run the docker image and expose port 5000
+* `make push` - push image to gcr.io/redis-dev-next-gen-cluster
+* `make deploy` - deploy the app and a service to k8s (current context and namespace are determined by the local kubectl configuration)
+* `make port-for` - start port forwarding for port 5000
+
+For development and local testing you can use `make run` 
+or just run the server with your favourite IDE.
+Just start a local redis raft and that is it. 
+```
+export FLOTILLA_DIR="<...>/next-gen/flotilla"
+redis-server --loglevel debug --cluster-enabled no --loadmodule "${FLOTILLA_DIR}"/deps/redisraft/redisraft.so --raft.addr 127.0.0.1:6379
+redis-cli -c raft.cluster init
+```
+and the 
+
+### Endpoints
+`NGC-Monkey` is web application written in python and use flask.
+All connections are synchronous and when there is a need to run a
+long task it spawns a thread.
+
+

--- a/ngc-monkey/k8s/deployment.yaml
+++ b/ngc-monkey/k8s/deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ngc-monkey
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ngc-monkey
+  template:
+    metadata:
+      labels:
+        app: ngc-monkey
+    spec:
+      containers:
+        - name: server
+          image: gcr.io/redis-dev-next-gen-cluster/ngc-monkey-server
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 5000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ngc-monkey
+spec:
+  selector:
+    app: ngc-monkey
+  ports:
+    - name: http
+      port: 5000
+      targetPort: 5000
+  type: ClusterIP

--- a/ngc-monkey/ngc-monkey/__main__.py
+++ b/ngc-monkey/ngc-monkey/__main__.py
@@ -1,0 +1,7 @@
+import logging
+
+from . import server
+
+
+logging.basicConfig(level="INFO")
+server.app.run(port=5000, host='0.0.0.0', debug=True)

--- a/ngc-monkey/ngc-monkey/raft_client.py
+++ b/ngc-monkey/ngc-monkey/raft_client.py
@@ -1,0 +1,37 @@
+import redis
+
+
+def _info_callback(_command, response, **kwargs):
+    """
+    Usually the cluster client returns a result with a
+    structure of {<node_name1>: <some value 1>, <node_name2>: <some value 2>}
+    But, if there is only one element in the result dict it will just return <some value>.
+    see https://github.com/redis/redis-py/blob/fcd8f98509c5c7c14ee5a3201b56b8bf755a4b7c/redis/cluster.py#L1198
+    This means that when we send execute_command("INFO", target_nodes=PRIMARIES) we cant know if the dict we got
+    is just single info response or a response from multiple nodes.
+    By adding a callback we are bypassing this behavior, so we always get back a dict
+    with {<node_name1>: <some value 1>, <node_name2>: <some value 2>}
+    """
+    return response
+
+
+class RaftClient(redis.RedisCluster):
+
+    def __init__(self, **kwargs):
+        super(RaftClient, self).__init__(**kwargs)
+        self.result_callbacks["INFO"] = _info_callback
+
+    def raft_info(self, target_nodes=None):
+        """
+        :param target_nodes: can take the same type as `execute_command` in `redis.Cluster`
+        https://github.com/redis/redis-py#getting-started
+        INFO has a strange api
+        """
+        return self.execute_command("INFO", "raft", target_nodes=target_nodes)
+
+    def assert_raft_is_up(self):
+        infos = self.raft_info(target_nodes=self.PRIMARIES)
+        for host, info in infos.items():
+            if info['raft_state'] != 'up':
+                raise Exception(f"Node {host} is not up")
+

--- a/ngc-monkey/ngc-monkey/server.py
+++ b/ngc-monkey/ngc-monkey/server.py
@@ -1,0 +1,67 @@
+import typing
+
+import flask
+from flask import Flask, request
+
+from .raft_client import RaftClient
+from .traffic_generator import TrafficGenerator
+
+app = Flask(__name__)
+_threads = {}
+
+
+@app.route('/run', methods=['POST'])
+def run():
+    """
+    Start a task (spawn a thread) that pushes keys
+    to redis and remember each key that was successfully set.
+    :param: db_name (String) the host name of the Redis Database
+    :return: 202 on success
+             500 on failure
+             409 if there is already a running task for the given db_name
+    """
+    db_name = request.json.get("db_name")
+    tg: typing.Optional[TrafficGenerator] = _threads.get(db_name)
+    if tg and tg.is_alive():
+        flask.abort(409, f"Traffic generation is already in progress for db {db_name}")
+    tg = TrafficGenerator(host=db_name)
+    try:
+        tg.redis_con.assert_raft_is_up()
+    except Exception as e:
+        flask.abort(500, f"Failed to connect to redis {db_name}. {str(e)}")
+
+    tg.start()
+    _threads[db_name] = tg
+    return flask.jsonify(201)
+
+
+@app.route('/check', methods=['POST'])
+def check():
+    """
+    Stop the thread connected to db_name and wait until it exits.
+    Then go over all keys that were sent, and assert that the DB has the correct value for them.
+    :param: db_name (String) the host name of the Redis Database
+    :return: 200 if the db_name has a running thread and result of the form `{ "result": "success" or "failure" }`
+             404 if the db_name does is not known
+    """
+    db_name = request.json.get("db_name")
+    traffic_gen: TrafficGenerator = _threads.get(db_name)
+    if traffic_gen is None:
+        flask.abort(404, description=f"DB {db_name} not found")
+    traffic_gen.stop_traffic()
+    traffic_gen.join(5.0)
+    result = traffic_gen.check()
+    status_code = 200 if result.is_success() else 500
+    return flask.jsonify({"result": f"{result}"}), status_code
+
+
+@app.route('/raft_info', methods=['POST'])
+def raft_info():
+    db_name = request.json.get("db_name")
+    redis_con = RaftClient(host=db_name, decode_responses=True)
+    return flask.jsonify(redis_con.raft_info(target_nodes=RaftClient.PRIMARIES))
+
+
+@app.route("/hello", methods=['POST', 'GET'])
+def hello():
+    return "Hello, World!"

--- a/ngc-monkey/ngc-monkey/traffic_generator.py
+++ b/ngc-monkey/ngc-monkey/traffic_generator.py
@@ -1,0 +1,66 @@
+import time
+import typing
+from enum import Enum
+
+from threading import Thread, Event
+import logging
+
+from .raft_client import RaftClient
+module_logger = logging.getLogger(__name__)
+
+
+class Result(str, Enum):
+    SUCCESS = "success"
+    FAILURE = "failure"
+
+    def is_success(self) -> bool:
+        return self == self.SUCCESS
+
+
+class TrafficGenerator(Thread):
+
+    def __init__(self, host: str):
+        super(TrafficGenerator, self).__init__()
+        self._event = Event()
+        self.host = host
+        self.redis_con = RaftClient(host=host, decode_responses=True)
+        self.redis_con.ping()
+        self._memory: typing.Dict[str, str] = {}
+        self.logger = None
+
+    def stop_traffic(self):
+        """
+        Tell the traffic generator to stop sending traffic and check data integrity
+        """
+        self._event.set()
+
+    def check(self) -> Result:
+        for k, v in self._memory.items():
+            if self.redis_con.get(k) != v:
+                return Result.FAILURE
+        return Result.SUCCESS
+
+    def _set_key_value(self, key: str, value: str):
+        try:
+            self.redis_con.set(key, value)
+            self._memory[key] = value
+        except Exception:
+            self.logger.exception(f"Failed to set {key}, {value}")
+
+    def should_stop(self) -> bool:
+        return self._event.is_set()
+
+    def run(self):
+        self.logger = module_logger.getChild(self.name)
+        self.logger.info(f"Starting traffic on redis '{self.host}' on thread '{self.name}'")
+
+        i = 0
+        while True:
+            if self.should_stop():
+                return
+
+            key = f"key-{i}"
+            value = f"value-{i}"
+            self._set_key_value(key, value)
+            i += 1
+            time.sleep(1)

--- a/ngc-monkey/requirements.txt
+++ b/ngc-monkey/requirements.txt
@@ -1,0 +1,3 @@
+Flask==2.2.2
+redis==4.4.2
+PyYAML==6.0

--- a/workflows/ngc-no-data-loss/ngc-no-data-loss.chartserviceversion.yaml
+++ b/workflows/ngc-no-data-loss/ngc-no-data-loss.chartserviceversion.yaml
@@ -1,0 +1,35 @@
+apiVersion: litmuchaos.io/v1alpha1
+kind: ChartServiceVersion
+metadata:
+  name: ngc-no-data-loss
+  annotations:
+    categories: redis
+    chartDescription: Generate traffic and check that the all expected data is present after we abuse the database
+spec:
+  displayName: Do stuff to the database (like killing pods) and check data integrity
+  categoryDescription: >
+    Injects chaos into redis NextGen Database and Check
+  experiments:
+    - pod-delete
+  keywords:
+    - NextGen
+    - pod delete
+  platforms:
+    - GKE
+    - Minikube
+    - Packet(Kubeadm)
+    - EKS
+    - AKS
+  maintainers:
+    - name: gil
+      email: gildaf@redis.com
+  provider:
+    name: NextGen Team
+  links:
+    - name: NextGen
+      url: https://github.com/redislabsdev/next-gen
+    - name: NextGen Litmus Workflows
+      url: https://github.com/gildaf/chaos-charts
+  icon:
+    - url:
+      mediatype: ""

--- a/workflows/ngc-no-data-loss/workflow.yaml
+++ b/workflows/ngc-no-data-loss/workflow.yaml
@@ -1,0 +1,375 @@
+kind: Workflow
+apiVersion: argoproj.io/v1alpha1
+metadata:
+  generateName: argowf-ngc-no-data-loss
+  namespace: litmus
+  labels:
+    subject: ngc-no-data-loss
+spec:
+  templates:
+    - name: custom-chaos
+      inputs: {}
+      outputs: {}
+      metadata: {}
+      steps:
+        - - name: install-chaos-experiments
+            template: install-chaos-experiments
+            arguments: {}
+        - - name: deploy-monkey-app
+            template: deploy-monkey-app
+            arguments: { }
+        - - name: deploy-monkey-app-service
+            template: deploy-monkey-app-service
+            arguments: { }
+        - - name: pod-delete
+            template: pod-delete
+            arguments: {}
+    - name: install-chaos-experiments
+      inputs:
+        artifacts:
+          - name: pod-delete
+            path: /tmp/pod-delete-pvx.yaml
+            raw: #  installing the pod delete experiment
+              data: >
+                apiVersion: litmuschaos.io/v1alpha1
+
+                description:
+                  message: |
+                    Deletes a pod belonging to a deployment/statefulset/daemonset
+                kind: ChaosExperiment
+
+                metadata:
+                  name: pod-delete
+                  labels:
+                    name: pod-delete
+                    app.kubernetes.io/part-of: litmus
+                    app.kubernetes.io/component: chaosexperiment
+                    app.kubernetes.io/version: 2.11.0
+                spec:
+                  definition:
+                    scope: Namespaced
+                    permissions:
+                      - apiGroups:
+                          - ""
+                        resources:
+                          - pods
+                        verbs:
+                          - create
+                          - delete
+                          - get
+                          - list
+                          - patch
+                          - update
+                          - deletecollection
+                      - apiGroups:
+                          - ""
+                        resources:
+                          - events
+                        verbs:
+                          - create
+                          - get
+                          - list
+                          - patch
+                          - update
+                      - apiGroups:
+                          - ""
+                        resources:
+                          - configmaps
+                        verbs:
+                          - get
+                          - list
+                      - apiGroups:
+                          - ""
+                        resources:
+                          - pods/log
+                        verbs:
+                          - get
+                          - list
+                          - watch
+                      - apiGroups:
+                          - ""
+                        resources:
+                          - pods/exec
+                        verbs:
+                          - get
+                          - list
+                          - create
+                      - apiGroups:
+                          - apps
+                        resources:
+                          - deployments
+                          - statefulsets
+                          - replicasets
+                          - daemonsets
+                        verbs:
+                          - list
+                          - get
+                      - apiGroups:
+                          - apps.openshift.io
+                        resources:
+                          - deploymentconfigs
+                        verbs:
+                          - list
+                          - get
+                      - apiGroups:
+                          - ""
+                        resources:
+                          - replicationcontrollers
+                        verbs:
+                          - get
+                          - list
+                      - apiGroups:
+                          - argoproj.io
+                        resources:
+                          - rollouts
+                        verbs:
+                          - list
+                          - get
+                      - apiGroups:
+                          - batch
+                        resources:
+                          - jobs
+                        verbs:
+                          - create
+                          - list
+                          - get
+                          - delete
+                          - deletecollection
+                      - apiGroups:
+                          - litmuschaos.io
+                        resources:
+                          - chaosengines
+                          - chaosexperiments
+                          - chaosresults
+                        verbs:
+                          - create
+                          - list
+                          - get
+                          - patch
+                          - update
+                          - delete
+                    image: litmuschaos/go-runner:2.11.0
+                    imagePullPolicy: Always
+                    args:
+                      - -c
+                      - ./experiments -name pod-delete
+                    command:
+                      - /bin/bash
+                    env:
+                      - name: TOTAL_CHAOS_DURATION
+                        value: "15"
+                      - name: RAMP_TIME
+                        value: ""
+                      - name: FORCE
+                        value: "true"
+                      - name: CHAOS_INTERVAL
+                        value: "5"
+                      - name: PODS_AFFECTED_PERC
+                        value: ""
+                      - name: LIB
+                        value: litmus
+                      - name: TARGET_PODS
+                        value: ""
+                      - name: NODE_LABEL
+                        value: ""
+                      - name: SEQUENCE
+                        value: parallel
+                    labels:
+                      name: pod-delete
+                      app.kubernetes.io/part-of: litmus
+                      app.kubernetes.io/component: experiment-job
+                      app.kubernetes.io/version: 2.11.0
+      outputs: {}
+      metadata: {}
+      container:
+        name: ""
+        image: litmuschaos/k8s:2.11.0
+        command:
+          - sh
+          - -c
+        args:
+          - kubectl apply -f /tmp/pod-delete-pvx.yaml -n
+            {{workflow.parameters.adminModeNamespace}} &&  sleep 30
+        resources: {}
+    - name: deploy-monkey-app
+      inputs:
+        artifacts:
+          - name: monkey-app-deployment
+            path: /tmp/monkey-app-deployment.yaml
+            raw: #  installing the pod delete experiment
+              data: >
+                apiVersion: apps/v1
+                
+                kind: Deployment
+                
+                metadata:
+                  name: ngc-monkey
+                spec:
+                  replicas: 1
+                  selector:
+                    matchLabels:
+                      app: ngc-monkey
+                  template:
+                    metadata:
+                      labels:
+                        app: ngc-monkey
+                    spec:
+                      containers:
+                        - name: server
+                          image: gcr.io/redis-dev-next-gen-cluster/ngc-monkey-server
+                          imagePullPolicy: Always
+                          ports:
+                            - containerPort: 5000
+      outputs: { }
+      metadata: { }
+      container:
+        name: ""
+        image: litmuschaos/k8s:2.11.0
+        command:
+          - sh
+          - -c
+        args:
+          - kubectl apply -f /tmp/monkey-app-deployment.yaml -n
+            {{workflow.parameters.adminModeNamespace}} &&  sleep 20
+        resources: { }
+    - name: deploy-monkey-app-service
+      inputs:
+        artifacts:
+          - name: monkey-app-service
+            path: /tmp/monkey-app-service.yaml
+            raw:
+              data: >
+                apiVersion: v1
+                
+                kind: Service
+                
+                metadata:
+                  name: ngc-monkey
+                spec:
+                  selector:
+                    app: ngc-monkey
+                  ports:
+                    - name: http
+                      port: 5000
+                      targetPort: 5000
+                  type: ClusterIP
+      outputs: { }
+      metadata: { }
+      container:
+        name: ""
+        image: litmuschaos/k8s:2.11.0
+        command:
+          - sh
+          - -c
+        args:
+          - kubectl apply -f /tmp/monkey-app-service.yaml -n
+            {{workflow.parameters.adminModeNamespace}} &&  sleep 10
+    - name: pod-delete
+      inputs:
+        artifacts:
+          - name: pod-delete-pvx
+            path: /tmp/chaosengine-pod-delete-pvx.yaml
+            raw:
+              data: >
+                apiVersion: litmuschaos.io/v1alpha1
+
+                kind: ChaosEngine
+
+                metadata:
+                  namespace: "{{workflow.parameters.adminModeNamespace}}"
+                  generateName: pod-delete-pvx
+                  labels:
+                    instance_id: 1ce1e171-67f0-484f-b6a5-c6bd7dd80f95
+                spec:
+                  appinfo:
+                    appns: testing-chaos
+                    applabel: RedisClusterRoles=FailoverCoordinator
+                    appkind: statefulset
+                  engineState: active
+                  chaosServiceAccount: litmus-admin
+                  experiments:
+                    - name: pod-delete
+                      spec:
+                        components:
+                          env:
+                            - name: TOTAL_CHAOS_DURATION
+                              value: "30"
+                            - name: CHAOS_INTERVAL
+                              value: "10"
+                            - name: FORCE
+                              value: "false"
+                            - name: PODS_AFFECTED_PERC
+                              value: "40"  # kill just one pod (assuming a 3 nodes raft cluster)
+                        probe:
+                          - name: hello-monkey-app
+                            type: httpProbe
+                            mode: SOT
+                            httpProbe/inputs:
+                              url: "http://ngc-monkey:5000/hello"
+                              responseTimeout: 1000  #in ms
+                              method:
+                                get:
+                                  criteria: "=="
+                                  responseCode: "200"
+                            runProperties:
+                              probeTimeout: 30
+                              retry: 2
+                              interval: 3
+                              stopOnFailure: false
+                          - name: start-traffic
+                            type: httpProbe
+                            mode: SOT
+                            httpProbe/inputs:
+                              url: "http://ngc-monkey:5000/run"
+                              responseTimeout: 1000  #in ms
+                              method:
+                                post:
+                                  contentType: "application/json; charset=UTF-8"
+                                  body: "{\"db_name\":\"smalldb.testing-chaos.svc.cluster.local\"}"
+                                  criteria: "oneOf"
+                                  responseCode: "200,201,202"
+                            runProperties:
+                              probeTimeout: 30
+                              retry: 2
+                              interval: 3
+                              stopOnFailure: false
+                          - name: stop-and-check
+                            type: httpProbe
+                            mode: EOT
+                            httpProbe/inputs:
+                              url: "http://ngc-monkey:5000/check"
+                              responseTimeout: 2000  #in ms
+                              method:
+                                post:
+                                  contentType: "application/json; charset=UTF-8"
+                                  body: "{\"db_name\":\"smalldb.testing-chaos.svc.cluster.local\"}"                                  
+                                  criteria: "=="
+                                  responseCode: "200"
+                            runProperties:
+                              probeTimeout: 30
+                              retry: 3
+                              interval: 3
+                              stopOnFailure: false
+      outputs: {}
+      metadata:
+        labels:
+          weight: "10"
+      container:
+        name: ""
+        image: litmuschaos/litmus-checker:2.11.0
+        args:
+          - -file=/tmp/chaosengine-pod-delete-pvx.yaml
+          - -saveName=/tmp/engine-name
+        resources: {}
+  entrypoint: custom-chaos
+  arguments:
+    parameters:
+      - name: adminModeNamespace
+        value: litmus
+  serviceAccountName: argo-chaos
+  securityContext:
+    runAsUser: 1000
+    runAsNonRoot: true
+status:
+  ? startedAt
+  ? finishedAt


### PR DESCRIPTION
This PR has two parts (two commits):
1. create a small application called ngc-monkey that enables sending traffic to redis database and later check that all keys that were sent sent still has the expected value after the experiment was run
2. create a workflow that installs the app, and then run a delete-pod experiment. The experiment has two probes:
    a. starts the traffic
    b. stop the traffic and check the data
 
  